### PR TITLE
Introduce meta classes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,8 @@
                 error,
                 "inside"
             ],
+			"indent": ["error", "tab"],
+			"no-mixed-spaces-and-tabs": error,
             "no-useless-call": error,
             "no-self-compare": error,
             "no-sequences": error,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,7 @@ var wrap = {
 
 var sources = ["./src/**/*.js"];
 var misc = ["./gulpfile.js", "./eslintrc.js"];
-var tests = ["./test/**/*.js"];
+var tests = ["./test/**/*.js", "!./test/custom-boot.js"];
 var all = sources.slice().concat(misc).concat(tests);
 
 gulp.task("default", ["lint", "test"]);

--- a/src/class.js
+++ b/src/class.js
@@ -1,0 +1,63 @@
+define([], function() {
+	var classModel = {};
+
+	// Return a new metaclass
+	classModel.new = function() {
+		var that = {};
+
+		that.subclasses = [];
+		that.extensions = [];
+
+		that.getClass = function() {
+			return null;
+		};
+
+		that.subclass = function() {
+			var superClass = this;
+			var klass = classModel.new();
+
+			klass.new = function(notFinal) {
+				if (klass.isAbstract && !notFinal) {
+					throwAbstractClassError(superClass);
+				}
+
+				if (klass.isSingleton && !notFinal) {
+					throwSingletonClassError(superClass);
+				}
+
+				var instance = superClass.new(true);
+
+				instance.getClass = function() {
+					return klass;
+				};
+
+				klass.extensions.forEach(function(extension) {
+					extension(instance);
+				});
+
+				return instance;
+			};
+
+			klass.superclass = superClass;
+			klass.subclasses = [];
+			superClass.subclasses.push(klass);
+			klass.extensions = [];
+			klass.proto = {};
+
+			return klass;
+		};
+
+		that.proto = {};
+		return that;
+	};
+
+	function throwAbstractClassError(klass) {
+		throw new Error("Cannot instantiate an instance of an abstract class");
+	}
+
+	function throwSingletonClassError(klass) {
+		throw new Error("Cannot create new instances of a singleton class, use `instance` instead.");
+	}
+
+	return classModel;
+});

--- a/src/object.js
+++ b/src/object.js
@@ -1,7 +1,7 @@
 define([
+	"./objectClass",
 	"./polyfills"
-], function() {
-
+], function(objectClass) {
 	/**
 	 * `object` is the base class of the object model.
 	 * It provides facilities to create subclasses and common methods.
@@ -48,238 +48,55 @@ define([
 	 * @param{{}} my
 	 * @return {object}
 	 */
-	var object = {
-		new: function(spec, my) {
-			my = my || {};
-			var that = {};
+	var object = objectClass.new();
+	object.new = function(spec, my) {
+		my = my || {};
+		var that = {};
 
-			that.getClass = function() {
-				return object;
-			};
-
-			/**
-			 * initialize is called by the framework upon object instantiation.
-			 */
-			my.initialize = function() {};
-
-			/**
-			 * Throws an error because the method should have been overridden.
-			 */
-			my.subclassResponsibility = subclassResponsibility;
-
-			/**
-			 * Getter/Setter generation
-			 */
-			my.get = function(propName, getter) {
-				if (!getter) {
-					getter = function() {
-						return my[propName];
-					};
-				}
-				that["get" + capitalized(propName)] = getter;
-			};
-
-			my.set = function(propName, setter) {
-				if (!setter) {
-					setter = function(value) {
-						my[propName] = value;
-						return value;
-					};
-				}
-				that["set" + capitalized(propName)] = setter;
-			};
-
-			// install extensions by hand for object, since we do not have the
-			// extension installation of the subclasses
-			that.getClass().extensions.forEach(function(extension) {
-				extension(that, my);
-			});
-
-			return that;
-		}
-	};
-
-	/**
-	 * Return an array of direct subclasses.
-	 */
-	object.subclasses = [];
-
-	/**
-	 * Return an array of all subclasses.
-	 */
-	object.allSubclasses = function() {
-		var allSubclasses = this.subclasses.slice();
-		this.subclasses.forEach(function(klass) {
-			klass.allSubclasses().forEach(function(subclass) {
-				allSubclasses.push(subclass);
-			});
-		});
-		return allSubclasses;
-	};
-
-	object.subclassResponsibility = subclassResponsibility;
-
-	/**
-	 * Return an array of all extensions of the class, see `object.extend`.
-	 */
-	object.extensions = [];
-
-	var superCallRegex = /\bsuper\b/;
-
-	/**
-	 * Return a new subclass, and register it to the array of `subclasses`.
-	 *
-	 * @param{function} builder Function used to build new instances of the
-	 * subclass.
-	 */
-	object.subclass = function(builder) {
-		var that = this;
-		var klass = {};
-
-		function klassBuilder(spec, my, notFinal) {
-			spec = spec || {};
-			my = my || {};
-
-			if (klass.isAbstract && !notFinal) {
-				throwAbstractClassError(that);
-			}
-
-			if (klass.isSingleton && !notFinal) {
-				throwSingletonClassError(that);
-			}
-
-			var instance = that.new(spec, my, true);
-
-			instance.getClass = function() {
-				return klass;
-			};
-
-			var superInstance = Object.assign({}, instance);
-			var superMy = Object.assign({}, my);
-
-			klass.extensions.forEach(function(extension) {
-				extension(instance, my);
-			});
-
-			builder(instance, my);
-			if (superCallRegex.test(builder)) {
-				installSuper(instance, superInstance);
-				installSuper(my, superMy);
-			}
-
-			if (!notFinal) {
-				my.initialize(spec);
-			}
-
-			return instance;
-		}
-
-		klass.new = klassBuilder;
-
-		klass.superclass = that;
-		klass.subclasses = [];
-		that.subclasses.push(klass);
-
-		// static inheritance
-		klass.classBuilder = that.classBuilder;
-		klass.classBuilder(klass);
-
-		return klass;
-	};
-
-	object.singletonSubclass = function(builder) {
-		var klass = this.subclass(builder);
-		var instance = klass.new();
-		klass.isSingleton = true;
-		klass.instance = function() {
-			return instance;
+		that.getClass = function() {
+			return object;
 		};
 
-		return klass;
-	};
+		/**
+		 * initialize is called by the framework upon object instantiation.
+		 */
+		my.initialize = function() {};
 
-	object.abstractSubclass = function(builder) {
-		var klass = this.subclass(builder);
-		klass.isAbstract = true;
-		return klass;
-	};
+		/**
+		 * Throws an error because the method should have been overridden.
+		 */
+		my.subclassResponsibility = subclassResponsibility;
 
-	object.class = function(builder) {
-		var that = this;
-
-		if (that === object) {
-			throw new Error("object class should not be extended.");
-		}
-
-		var superClassBuilder = that.classBuilder;
-		that.classBuilder = function(klass) {
-			superClassBuilder(klass);
-			builder(klass);
+		/**
+		 * Getter/Setter generation
+		 */
+		my.get = function(propName, getter) {
+			if (!getter) {
+				getter = function() {
+					return my[propName];
+				};
+			}
+			that["get" + capitalized(propName)] = getter;
 		};
 
-		that.classBuilder(that);
-	};
-
-	object.classBuilder = function(that) {
-		// TODO: use Object.assign?
-		that.class = object.class;
-		that.subclass = object.subclass;
-		that.singletonSubclass = object.singletonSubclass;
-		that.abstractSubclass = object.abstractSubclass;
-		that.allSubclasses = object.allSubclasses;
-		that.subclassResponsibility = subclassResponsibility;
-		that.extend = object.extend;
-		that.extensions = [];
-	};
-
-	/**
-	 * Mutate public functions of `obj` that make use of `super()` by binding
-	 * `super` from within each public function of `obj` to the function in
-	 * `proto`.
-	 */
-	function installSuper(obj, proto) {
-		Object.keys(obj).forEach(function(name) {
-			if (typeof proto[name] === "function" &&
-				typeof obj[name] === "function" &&
-				superCallRegex.test(obj[name]) && !obj[name].superInstalled) {
-				var superFn = proto[name];
-				obj[name] = (function(name, fn) {
-					return function() {
-						var tmp = obj.super;
-						obj.super = superFn;
-						var returnValue = fn.apply(obj, arguments);
-						obj.super = tmp;
-
-						// We reached the top of the stack regarding super
-						// calls, so cleanup the namespace.
-						if (obj.super === undefined) {
-							delete obj.super;
-						}
-
-						return returnValue;
-					};
-				})(name, obj[name]);
-				obj[name].superInstalled = true;
+		my.set = function(propName, setter) {
+			if (!setter) {
+				setter = function(value) {
+					my[propName] = value;
+					return value;
+				};
 			}
+			that["set" + capitalized(propName)] = setter;
+		};
+
+		// install extensions by hand for object, since we do not have the
+		// extension installation of the subclasses
+		that.getClass().extensions.forEach(function(extension) {
+			extension(that, my);
 		});
-	}
 
-	/**
-	 * Extend the class with new methods/properties.
-	 * @param{function} builder takes the same arguments as
-	 * `object.subclass`: `that`, `spec` and `my`.
-	 */
-	object.extend = function(builder) {
-		this.extensions.push(builder);
+		return that;
 	};
-
-	function throwAbstractClassError(klass) {
-		throw new Error("Cannot instantiate an instance of an abstract class");
-	}
-
-	function throwSingletonClassError(klass) {
-		throw new Error("Cannot create new instances of a singleton class, use `instance` instead.");
-	}
 
 	/**
 	 * Helpers

--- a/src/objectClass.js
+++ b/src/objectClass.js
@@ -1,0 +1,192 @@
+define([
+	"./class"
+], function(classModel) {
+	var superCallRegex = /\bsuper\b/;
+
+	/**
+	 * objectClass is the meta class of the class `object`
+	 * @type {{}}
+	 */
+	var objectClass = classModel.new();
+	objectClass.name = "objectClass";
+	objectClass.classBuilder = function() {
+
+	};
+
+	objectClass.new = function() {
+		var that = {};
+
+		var metaclass = this;
+		that.subclasses = [];
+
+		/**
+		 * Return an array of all extensions of the class, see `object.extend`.
+		 */
+		that.extensions = [];
+
+		that.getSubclasses = function() {
+			return this.subclasses;
+		};
+
+		that.allSubclasses = function() {
+			var allSubclasses = this.getSubclasses().slice();
+			this.getSubclasses().forEach(function(klass) {
+				klass.allSubclasses().forEach(function(subclass) {
+					allSubclasses.push(subclass);
+				});
+			});
+			return allSubclasses;
+		};
+
+		that.class = function(builder) {
+			var that = this;
+
+			if (that.getClass() === objectClass) {
+				throw new Error("object class should not be extended.");
+			}
+
+			builder(that);
+			that.getClass().extensions.push(builder);
+
+			if (superCallRegex.test(builder)) {
+				installSuper(that, that.superclass);
+			}
+		};
+
+		that.abstractSubclass = function(builder) {
+			var klass = this.subclass(builder);
+			klass.isAbstract = true;
+			return klass;
+		};
+
+		that.singletonSubclass = function(builder) {
+			var klass = this.subclass(builder);
+			var instance = klass.new();
+			klass.isSingleton = true;
+			klass.instance = function() {
+				return instance;
+			};
+
+			return klass;
+		};
+
+		/**
+		 * Extend the class with new methods/properties.
+		 * @param{function} builder takes the same arguments as
+		 * `object.subclass`: `that`, `spec` and `my`.
+		 */
+		that.extend = function(builder) {
+			this.extensions.push(builder);
+		};
+
+		/**
+		 * Return a new subclass, and register it to the array of `subclasses`.
+		 *
+		 * @param{function} builder Function used to build new instances of the
+		 * subclass.
+		 */
+		that.subclass = function(builder) {
+			var superClass = this;
+
+			var superMetaClass = superClass.getClass();
+			var metaClass = superMetaClass.subclass();
+
+			var klass = metaClass.new();
+
+			klass.new = function(spec, my, notFinal) {
+				spec = spec || {};
+				my = my || {};
+
+				if (klass.isAbstract && !notFinal) {
+					throwAbstractClassError(superClass);
+				}
+
+				if (klass.isSingleton && !notFinal) {
+					throwSingletonClassError(superClass);
+				}
+
+				var instance = superClass.new(spec, my, true);
+
+				instance.getClass = function() {
+					return klass;
+				};
+
+				var superInstance = Object.assign({}, instance);
+				var superMy = Object.assign({}, my);
+
+				klass.extensions.forEach(function(extension) {
+					extension(instance, my);
+				});
+
+				if (builder) {
+					builder(instance, my);
+				}
+
+				if (superCallRegex.test(builder)) {
+					installSuper(instance, superInstance);
+					installSuper(my, superMy);
+				}
+
+				if (!notFinal) {
+					my.initialize(spec);
+				}
+
+				return instance;
+			};
+
+			klass.superclass = superClass;
+			klass.subclasses = [];
+			superClass.subclasses.push(klass);
+
+			return klass;
+		};
+
+		that.getClass = function() {
+			return metaclass;
+		};
+
+		return that;
+	};
+
+	/**
+	 * Mutate public functions of `obj` that make use of `super()` by binding
+	 * `super` from within each public function of `obj` to the function in
+	 * `proto`.
+	 */
+	function installSuper(obj, proto) {
+		Object.keys(obj).forEach(function(name) {
+			if (typeof proto[name] === "function" &&
+				typeof obj[name] === "function" &&
+				superCallRegex.test(obj[name]) && !obj[name].superInstalled) {
+				var superFn = proto[name];
+				obj[name] = (function(name, fn) {
+					return function() {
+						var tmp = obj.super;
+						obj.super = superFn;
+						var returnValue = fn.apply(obj, arguments);
+						obj.super = tmp;
+
+						// We reached the top of the stack regarding super
+						// calls, so cleanup the namespace.
+						if (obj.super === undefined) {
+							delete obj.super;
+						}
+
+						return returnValue;
+					};
+				})(name, obj[name]);
+				obj[name].superInstalled = true;
+			}
+		});
+	}
+
+	function throwAbstractClassError(klass) {
+		throw new Error("Cannot instantiate an instance of an abstract class");
+	}
+
+	function throwSingletonClassError(klass) {
+		throw new Error("Cannot create new instances of a singleton class, use `instance` instead.");
+	}
+
+	return objectClass;
+});

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,0 +1,27 @@
+define([], function() {
+	/**
+	 * Polyfill for Object.assign
+	 */
+	if (typeof Object.assign !== "function") {
+		(function() {
+			Object.assign = function(target) {
+				if (target === undefined || target === null) {
+					throw new TypeError("Cannot convert undefined or null to object");
+				}
+
+				var output = Object(target);
+				for (var index = 1; index < arguments.length; index++) {
+					var source = arguments[index];
+					if (source !== undefined && source !== null) {
+						for (var nextKey in source) {
+							if (source.hasOwnProperty(nextKey)) {
+								output[nextKey] = source[nextKey];
+							}
+						}
+					}
+				}
+				return output;
+			};
+		})();
+	}
+});

--- a/src/testCase.js
+++ b/src/testCase.js
@@ -83,7 +83,7 @@ define([
 		that.subclass = (function(superSubclass) {
 			return function(builder) {
 				var klass = superSubclass.apply(that, [builder]);
-				var instance = klass();
+				var instance = klass.new();
 				klass.isSingleton = true;
 				klass.instance = function() {
 					return instance;

--- a/test/src/abstractSubclassSpec.js
+++ b/test/src/abstractSubclassSpec.js
@@ -12,7 +12,7 @@ define(["src/object"], function(object) {
 		it("Cannot instantiate abstract classes", function() {
 			var abstractClass = object.abstractSubclass(function(that, my) {});
 
-			expect(abstractClass).toThrow();
+			expect(abstractClass.new).toThrow();
 		});
 
 		it("Abstract classes should be abstract", function() {
@@ -24,7 +24,7 @@ define(["src/object"], function(object) {
 			var abstractClass = object.abstractSubclass(function(that, my) {});
 			var concreteSubclass = abstractClass.subclass(function(that, my) {});
 
-			expect(concreteSubclass).not.toThrow();
+			expect(concreteSubclass.new).not.toThrow();
 		});
 
 		it("Can create abstract subclasses of abstract classes", function() {

--- a/test/src/classInheritanceSpec.js
+++ b/test/src/classInheritanceSpec.js
@@ -23,7 +23,6 @@ define(["src/object"], function(object) {
 			});
 
 			var dog = animal.subclass(function() {});
-
 			expect(dog.bar()).toBe(true);
 		});
 
@@ -104,6 +103,27 @@ define(["src/object"], function(object) {
 
 			expect(dog.named("milou").getClass()).toEqual(dog);
 			expect(animal.named("babar").getClass()).toEqual(animal);
+		});
+
+		it("support supercalls on class side", function() {
+			var sentinel = false;
+			var animal = object.subclass();
+			animal.class(function(that) {
+				that.foo = function() {
+					sentinel = true;
+				};
+			});
+			var dog = animal.subclass();
+			dog.class(function(that) {
+				that.foo = function() {
+					sentinel = false;
+					that.super();
+				};
+			});
+
+			dog.foo();
+
+			expect(sentinel).toBeTruthy();
 		});
 	});
 });

--- a/test/src/classInheritanceSpec.js
+++ b/test/src/classInheritanceSpec.js
@@ -1,109 +1,109 @@
 define(["src/object"], function(object) {
 
-    describe("class-inheritance", function() {
+	describe("class-inheritance", function() {
 
-        it("Cannot add class-side methods to Object", function() {
+		it("Cannot add class-side methods to Object", function() {
 			var addMethod = function() {
-                object.class(function(that) {
-                    that.foo = function() {
-                        return true;
-                    };
-                });
+				object.class(function(that) {
+					that.foo = function() {
+						return true;
+					};
+				});
 			};
 
 			expect(addMethod).toThrow();
 		});
 
-        it("Class-side methods are inherited in direct subclasses", function() {
-            var animal = object.subclass(function() {});
-            animal.class(function(that) {
-                that.bar = function() {
-                    return true;
-                };
-            });
+		it("Class-side methods are inherited in direct subclasses", function() {
+			var animal = object.subclass(function() {});
+			animal.class(function(that) {
+				that.bar = function() {
+					return true;
+				};
+			});
 
-            var dog = animal.subclass(function() {});
+			var dog = animal.subclass(function() {});
 
-            expect(dog.bar()).toBe(true);
+			expect(dog.bar()).toBe(true);
 		});
 
-        it("Class-side methods are inherited in direct subclasses", function() {
-            var animal = object.subclass(function() {});
-            animal.class(function(that) {
-                that.bar = function() {
-                    return true;
-                };
-            });
+		it("Class-side methods are inherited in direct subclasses", function() {
+			var animal = object.subclass(function() {});
+			animal.class(function(that) {
+				that.bar = function() {
+					return true;
+				};
+			});
 
-            var dog = animal.subclass(function() {});
+			var dog = animal.subclass(function() {});
 
-            expect(dog.bar()).toBe(true);
+			expect(dog.bar()).toBe(true);
 		});
 
-        it("Class-side methods are not propagated to the superclass", function() {
-            var animal = object.subclass(function() {});
-            animal.class(function(that) {
-                that.bar = function() {
-                    return true;
-                };
-            });
+		it("Class-side methods are not propagated to the superclass", function() {
+			var animal = object.subclass(function() {});
+			animal.class(function(that) {
+				that.bar = function() {
+					return true;
+				};
+			});
 
-            var dog = animal.subclass(function() {});
-            dog.class(function(that) {
-                that.baz = function() {
-                    return true;
-                };
-            });
+			var dog = animal.subclass(function() {});
+			dog.class(function(that) {
+				that.baz = function() {
+					return true;
+				};
+			});
 
-            expect(object.bar).toEqual(undefined);
-            expect(animal.baz).toEqual(undefined);
-        });
-
-        it("Class-side method reference the correct class when inherited", function() {
-            var animal = object.subclass(function() {});
-            animal.class(function(that) {
-                that.foo = function() {
-                    return that.bar();
-                };
-
-                that.bar = function() {
-                    return false;
-                };
-            });
-
-            var dog = animal.subclass(function() {});
-            dog.class(function(that) {
-                that.bar = function() {
-                    return true;
-                };
-            });
-
-            expect(dog.foo()).toBe(true);
+			expect(object.bar).toEqual(undefined);
+			expect(animal.baz).toEqual(undefined);
 		});
 
-        it("Custom constructors instantiate objects of the correct class", function() {
-            var animal = object.subclass(function(that, my) {
-                my.initialize = function(spec) {
-                    my.name = spec.name;
-                };
+		it("Class-side method reference the correct class when inherited", function() {
+			var animal = object.subclass(function() {});
+			animal.class(function(that) {
+				that.foo = function() {
+					return that.bar();
+				};
 
-                that.getName = function() {
-                    return my.name;
-                };
-            });
+				that.bar = function() {
+					return false;
+				};
+			});
 
-            animal.class(function(that) {
-                that.named = function(name) {
+			var dog = animal.subclass(function() {});
+			dog.class(function(that) {
+				that.bar = function() {
+					return true;
+				};
+			});
+
+			expect(dog.foo()).toBe(true);
+		});
+
+		it("Custom constructors instantiate objects of the correct class", function() {
+			var animal = object.subclass(function(that, my) {
+				my.initialize = function(spec) {
+					my.name = spec.name;
+				};
+
+				that.getName = function() {
+					return my.name;
+				};
+			});
+
+			animal.class(function(that) {
+				that.named = function(name) {
 					return that.new({
-                        name: name
-                    });
-                };
-            });
+						name: name
+					});
+				};
+			});
 
-            var dog = animal.subclass(function() {});
+			var dog = animal.subclass(function() {});
 
-            expect(dog.named("milou").getClass()).toEqual(dog);
-            expect(animal.named("babar").getClass()).toEqual(animal);
-        });
-    });
+			expect(dog.named("milou").getClass()).toEqual(dog);
+			expect(animal.named("babar").getClass()).toEqual(animal);
+		});
+	});
 });

--- a/test/src/classInheritanceSpec.js
+++ b/test/src/classInheritanceSpec.js
@@ -3,18 +3,15 @@ define(["src/object"], function(object) {
     describe("class-inheritance", function() {
 
         it("Cannot add class-side methods to Object", function() {
-            var exception;
-            try {
+			var addMethod = function() {
                 object.class(function(that) {
                     that.foo = function() {
                         return true;
                     };
                 });
-            } catch (e) {
-                exception = true;
-            }
+			};
 
-            expect(exception).toBe(true);
+			expect(addMethod).toThrow();
 		});
 
         it("Class-side methods are inherited in direct subclasses", function() {
@@ -97,7 +94,7 @@ define(["src/object"], function(object) {
 
             animal.class(function(that) {
                 that.named = function(name) {
-                    return that({
+					return that.new({
                         name: name
                     });
                 };

--- a/test/src/classReferenceSpec.js
+++ b/test/src/classReferenceSpec.js
@@ -3,7 +3,7 @@ define(["src/object"], function(object) {
     describe("class-reference", function() {
 
         it("Instance of object can access their class", function() {
-            var o = object();
+            var o = object.new();
 
             expect(o.getClass()).toEqual(object);
         });
@@ -11,7 +11,7 @@ define(["src/object"], function(object) {
         it("Instances of subclasses of object reference the correct class", function() {
             var animal = object.subclass(function(that, my) {});
 
-            var a = animal();
+            var a = animal.new();
 
             expect(a.getClass()).toEqual(animal);
         });
@@ -20,7 +20,7 @@ define(["src/object"], function(object) {
             var animal = object.subclass(function(that, my) {});
             var dog = animal.subclass(function(that, my) {});
 
-            var d = dog();
+            var d = dog.new();
 
             expect(d.getClass()).toEqual(dog);
         });
@@ -38,7 +38,7 @@ define(["src/object"], function(object) {
                 };
             });
 
-            var a = animal();
+            var a = animal.new();
 
             expect(a.foo()).toBe(true);
         });

--- a/test/src/classReferenceSpec.js
+++ b/test/src/classReferenceSpec.js
@@ -1,46 +1,46 @@
 define(["src/object"], function(object) {
 
-    describe("class-reference", function() {
+	describe("class-reference", function() {
 
-        it("Instance of object can access their class", function() {
-            var o = object.new();
+		it("Instance of object can access their class", function() {
+			var o = object.new();
 
-            expect(o.getClass()).toEqual(object);
-        });
+			expect(o.getClass()).toEqual(object);
+		});
 
-        it("Instances of subclasses of object reference the correct class", function() {
-            var animal = object.subclass(function(that, my) {});
+		it("Instances of subclasses of object reference the correct class", function() {
+			var animal = object.subclass(function(that, my) {});
 
-            var a = animal.new();
+			var a = animal.new();
 
-            expect(a.getClass()).toEqual(animal);
-        });
+			expect(a.getClass()).toEqual(animal);
+		});
 
-        it("Instances of subclasses of subclasses refer to the correct class", function() {
-            var animal = object.subclass(function(that, my) {});
-            var dog = animal.subclass(function(that, my) {});
+		it("Instances of subclasses of subclasses refer to the correct class", function() {
+			var animal = object.subclass(function(that, my) {});
+			var dog = animal.subclass(function(that, my) {});
 
-            var d = dog.new();
+			var d = dog.new();
 
-            expect(d.getClass()).toEqual(dog);
-        });
+			expect(d.getClass()).toEqual(dog);
+		});
 
-        it("Can refer to class-side methods from an instance", function() {
-            var animal = object.subclass(function(that, my) {
-                that.foo = function() {
-                    return that.getClass().foo();
-                };
-            });
+		it("Can refer to class-side methods from an instance", function() {
+			var animal = object.subclass(function(that, my) {
+				that.foo = function() {
+					return that.getClass().foo();
+				};
+			});
 
-            animal.class(function(that) {
-                that.foo = function() {
-                    return true;
-                };
-            });
+			animal.class(function(that) {
+				that.foo = function() {
+					return true;
+				};
+			});
 
-            var a = animal.new();
+			var a = animal.new();
 
-            expect(a.foo()).toBe(true);
-        });
-    });
+			expect(a.foo()).toBe(true);
+		});
+	});
 });

--- a/test/src/extensionSpec.js
+++ b/test/src/extensionSpec.js
@@ -9,7 +9,7 @@ define(["src/object"], function(object) {
 				};
 			});
 
-			var o = object();
+			var o = object.new();
 
 			expect(o.isObject()).toBe(true);
 		});
@@ -23,7 +23,7 @@ define(["src/object"], function(object) {
 
 			var animal = object.subclass(function() {});
 
-			var a = animal();
+			var a = animal.new();
 
 			expect(!a.isDog()).toBe(true);
 		});
@@ -47,8 +47,8 @@ define(["src/object"], function(object) {
 				};
 			});
 
-			var a = animal();
-			var d = dog();
+			var a = animal.new();
+			var d = dog.new();
 
 			expect(a.isAnimal()).toBe(true);
 			expect(!a.isDog()).toBe(true);
@@ -75,7 +75,7 @@ define(["src/object"], function(object) {
 				};
 			});
 
-			var a = animal();
+			var a = animal.new();
 			expect(a.foo()).toBe(true);
 		});
 
@@ -92,7 +92,7 @@ define(["src/object"], function(object) {
 				};
 			});
 
-			var a = animal();
+			var a = animal.new();
 			expect(!a.foo()).toBe(true);
 		});
 	});

--- a/test/src/getterSetterSpec.js
+++ b/test/src/getterSetterSpec.js
@@ -9,7 +9,7 @@ define(["src/object"], function(object) {
 				my.get("name");
 			});
 
-			var a = animal({name: "milou"});
+			var a = animal.new({name: "milou"});
 			expect(a.getName()).toBe("milou");
 		});
 
@@ -20,7 +20,7 @@ define(["src/object"], function(object) {
 				});
 			});
 
-			var a = animal();
+			var a = animal.new();
 			expect(a.getName()).toBe("milou");
 		});
 
@@ -37,7 +37,7 @@ define(["src/object"], function(object) {
 				my.set("name");
 			});
 
-			var a = animal({name: "milou"});
+			var a = animal.new({name: "milou"});
 			a.setName("Charlie");
 			expect(a.getName()).toBe("Charlie");
 		});
@@ -53,7 +53,7 @@ define(["src/object"], function(object) {
 				});
 			});
 
-			var a = animal();
+			var a = animal.new();
 			a.setName("milou");
 			expect(a.getName()).toBe("animal named milou");
 		});
@@ -66,7 +66,7 @@ define(["src/object"], function(object) {
 
 			var dog = animal.subclass(function(that, my) {});
 
-			var d = dog();
+			var d = dog.new();
 			d.setName("milou");
 			expect(d.getName()).toBe("milou");
 		});

--- a/test/src/inheritanceSpec.js
+++ b/test/src/inheritanceSpec.js
@@ -17,7 +17,7 @@ define(["src/object"], function(object) {
 
 			var dog = animal.subclass(function(that, my) {});
 
-			var milou = dog({name: "milou"});
+			var milou = dog.new({name: "milou"});
 
 			expect(milou.toString()).toEqual("milou");
 		});
@@ -41,7 +41,7 @@ define(["src/object"], function(object) {
 				};
 			});
 
-			var milou = dog({name: "milou"});
+			var milou = dog.new({name: "milou"});
 
 			expect(milou.toString()).toEqual("Woof");
 		});
@@ -61,7 +61,7 @@ define(["src/object"], function(object) {
 
 			var dog = animal.subclass(function(that, my) {});
 
-			var milou = dog({name: "milou"});
+			var milou = dog.new({name: "milou"});
 
 			expect(milou.toString()).toEqual("milou");
 		});
@@ -85,7 +85,7 @@ define(["src/object"], function(object) {
 				};
 			});
 
-			var milou = dog({name: "milou"});
+			var milou = dog.new({name: "milou"});
 
 			expect(milou.toString()).toEqual("Woof");
 		});
@@ -101,7 +101,7 @@ define(["src/object"], function(object) {
 			var dog = mammal.abstractSubclass(function() {});
 			var shepherd = dog.subclass(function() {});
 
-			var milou = shepherd();
+			var milou = shepherd.new();
 
 			expect(milou.notPreviouslyDefinedFunction()).toBeTruthy();
 		});

--- a/test/src/initializationSpec.js
+++ b/test/src/initializationSpec.js
@@ -12,7 +12,7 @@ define(["src/object"], function(object) {
             });
 
             expect(!initialized).toBe(true);
-            animal();
+			animal.new();
             expect(initialized).toBe(true);
         });
 
@@ -31,7 +31,7 @@ define(["src/object"], function(object) {
                 };
             });
 
-            dog();
+			dog.new();
             expect(initializeCalls).toEqual(1);
         });
 
@@ -52,8 +52,8 @@ define(["src/object"], function(object) {
                 };
             });
 
-            var d = dog();
-            var a = animal();
+			var d = dog.new();
+			var a = animal.new();
             expect(a.bar).toEqual("animal");
             expect(d.bar).toEqual("dog");
         });
@@ -73,7 +73,7 @@ define(["src/object"], function(object) {
                 };
             });
 
-            var d = dog();
+			var d = dog.new();
             expect(d.foo).toEqual(1);
             expect(d.bar).toEqual(2);
         });

--- a/test/src/initializationSpec.js
+++ b/test/src/initializationSpec.js
@@ -1,81 +1,81 @@
 define(["src/object"], function(object) {
 
-    describe("initialization", function() {
+	describe("initialization", function() {
 
-        it("initialize should be called upon object creation", function() {
-            var initialized = false;
+		it("initialize should be called upon object creation", function() {
+			var initialized = false;
 
-            var animal = object.subclass(function(that, my) {
-                my.initialize = function() {
-                    initialized = true;
-                };
-            });
+			var animal = object.subclass(function(that, my) {
+				my.initialize = function() {
+					initialized = true;
+				};
+			});
 
-            expect(!initialized).toBe(true);
+			expect(!initialized).toBe(true);
 			animal.new();
-            expect(initialized).toBe(true);
-        });
+			expect(initialized).toBe(true);
+		});
 
-        it("initialize should be called only once", function() {
-            var initializeCalls = 0;
+		it("initialize should be called only once", function() {
+			var initializeCalls = 0;
 
-            var animal = object.subclass(function(that, my) {
-                my.initialize = function() {
-                    initializeCalls += 1;
-                };
-            });
+			var animal = object.subclass(function(that, my) {
+				my.initialize = function() {
+					initializeCalls += 1;
+				};
+			});
 
-            var dog = animal.subclass(function(that, my) {
-                my.initialize = function() {
-                    initializeCalls += 1;
-                };
-            });
+			var dog = animal.subclass(function(that, my) {
+				my.initialize = function() {
+					initializeCalls += 1;
+				};
+			});
 
 			dog.new();
-            expect(initializeCalls).toEqual(1);
-        });
+			expect(initializeCalls).toEqual(1);
+		});
 
-        it("can use overrides within initialize", function() {
-            var animal = object.subclass(function(that, my) {
-                my.initialize = function() {
-                    that.foo();
-                };
+		it("can use overrides within initialize", function() {
+			var animal = object.subclass(function(that, my) {
+				my.initialize = function() {
+					that.foo();
+				};
 
-                that.foo = function() {
-                    that.bar = "animal";
-                };
-            });
+				that.foo = function() {
+					that.bar = "animal";
+				};
+			});
 
-            var dog = animal.subclass(function(that, my) {
-                that.foo = function() {
-                    that.bar = "dog";
-                };
-            });
+			var dog = animal.subclass(function(that, my) {
+				that.foo = function() {
+					that.bar = "dog";
+				};
+			});
 
 			var d = dog.new();
 			var a = animal.new();
-            expect(a.bar).toEqual("animal");
-            expect(d.bar).toEqual("dog");
-        });
+			expect(a.bar).toEqual("animal");
+			expect(d.bar).toEqual("dog");
+		});
 
-        it("can call super from initialize", function() {
-            var animal = object.subclass(function(that, my) {
-                my.initialize = function() {
-                    my.super();
-                    that.foo = 1;
-                };
-            });
+		it("can call super from initialize", function() {
+			var animal = object.subclass(function(that, my) {
+				my.initialize = function() {
+					my.super();
+					that.foo = 1;
+				};
+			});
 
-            var dog = animal.subclass(function(that, my) {
-                my.initialize = function() {
-                    my.super();
-                    that.bar = 2;
-                };
-            });
+			var dog = animal.subclass(function(that, my) {
+				my.initialize = function() {
+					my.super();
+					that.bar = 2;
+				};
+			});
 
 			var d = dog.new();
-            expect(d.foo).toEqual(1);
-            expect(d.bar).toEqual(2);
-        });
-    });
+			expect(d.foo).toEqual(1);
+			expect(d.bar).toEqual(2);
+		});
+	});
 });

--- a/test/src/singletonSpec.js
+++ b/test/src/singletonSpec.js
@@ -9,7 +9,7 @@ define(["src/object"], function(object) {
 		it("cannot create instances of singleton classes", function() {
 			var animal = object.singletonSubclass(function(that, my) { });
 			expect(function() {
-				animal();
+				animal.new();
 			}).toThrowError("Cannot create new instances of a singleton class, use `instance` instead.");
 		});
 
@@ -56,10 +56,10 @@ define(["src/object"], function(object) {
 				my.get("name");
 			});
 			var dog = animal.subclass(function() {});
-			var instance1 = dog({
+			var instance1 = dog.new({
 				name: "Milou"
 			});
-			var instance2 = dog({
+			var instance2 = dog.new({
 				name: "Rantanplan"
 			});
 

--- a/test/src/subclassCreationSpec.js
+++ b/test/src/subclassCreationSpec.js
@@ -1,18 +1,18 @@
 define(["src/object"], function(object) {
 
-    describe("subclass creation", function() {
+	describe("subclass creation", function() {
 
-        it("Can create a subclass", function() {
-            var animal = object.subclass(function() {});
+		it("Can create a subclass", function() {
+			var animal = object.subclass(function() {});
 
-            expect(object.subclasses).toContain(animal);
-        });
+			expect(object.subclasses).toContain(animal);
+		});
 
-        it("Can create a subclass of a subclass", function() {
-            var animal = object.subclass(function() {});
-            var dog = animal.subclass(function() {});
+		it("Can create a subclass of a subclass", function() {
+			var animal = object.subclass(function() {});
+			var dog = animal.subclass(function() {});
 
-            expect(animal.subclasses).toEqual([dog]);
-        });
-    });
+			expect(animal.subclasses).toEqual([dog]);
+		});
+	});
 });

--- a/test/src/superSpec.js
+++ b/test/src/superSpec.js
@@ -19,7 +19,7 @@ define(["src/object"], function(object) {
                 };
             });
 
-            var milou = dog({name: "milou"});
+			var milou = dog.new({name: "milou"});
 
             expect(milou.getName()).toEqual("dog named milou");
         });
@@ -46,7 +46,7 @@ define(["src/object"], function(object) {
                 };
             });
 
-            var milou = dog({name: "milou"});
+			var milou = dog.new({name: "milou"});
 
             expect(milou.toString()).toEqual("dog named milou");
         });
@@ -73,7 +73,7 @@ define(["src/object"], function(object) {
                 };
             });
 
-            var milou = dog();
+			var milou = dog.new();
 
             expect(milou.toString()).toEqual("a dog named: milou");
         });
@@ -92,7 +92,7 @@ define(["src/object"], function(object) {
                 };
             });
 
-            var milou = dog();
+			var milou = dog.new();
             var foo = milou.foo(4);
 
             expect(foo).toEqual(5);
@@ -110,7 +110,7 @@ define(["src/object"], function(object) {
 				};
 			});
 
-			var milou = dog();
+			var milou = dog.new();
 			milou.foo();
 
 			var keys = Object.keys(milou);
@@ -132,7 +132,7 @@ define(["src/object"], function(object) {
 
 			var baz = bar.subclass(function(that, my) {});
 
-			expect(baz().foo()).toBe(2);
+			expect(baz.new().foo()).toBe(2);
 		});
     });
 });

--- a/test/src/superSpec.js
+++ b/test/src/superSpec.js
@@ -1,102 +1,102 @@
 define(["src/object"], function(object) {
 
-    describe("super", function() {
+	describe("super", function() {
 
-        it("super can be called within public methods", function() {
-            var animal = object.subclass(function(that, my) {
-                my.initialize = function(spec) {
-                    my.super();
-                    my.name = spec.name;
-                };
-                that.getName = function() {
-                    return my.name;
-                };
-            });
+		it("super can be called within public methods", function() {
+			var animal = object.subclass(function(that, my) {
+				my.initialize = function(spec) {
+					my.super();
+					my.name = spec.name;
+				};
+				that.getName = function() {
+					return my.name;
+				};
+			});
 
-            var dog = animal.subclass(function(that, my) {
-                that.getName = function() {
-                    return "dog named " + that.super();
-                };
-            });
-
-			var milou = dog.new({name: "milou"});
-
-            expect(milou.getName()).toEqual("dog named milou");
-        });
-
-        it("super can be called within protected methods", function() {
-            var animal = object.subclass(function(that, my) {
-                my.initialize = function(spec) {
-                    my.super();
-                    my.name = spec.name;
-                };
-
-                that.toString = function() {
-                    return my.getName();
-                };
-
-                my.getName = function() {
-                    return my.name;
-                };
-            });
-
-            var dog = animal.subclass(function(that, my) {
-                my.getName = function() {
-                    return "dog named " + my.super();
-                };
-            });
+			var dog = animal.subclass(function(that, my) {
+				that.getName = function() {
+					return "dog named " + that.super();
+				};
+			});
 
 			var milou = dog.new({name: "milou"});
 
-            expect(milou.toString()).toEqual("dog named milou");
-        });
+			expect(milou.getName()).toEqual("dog named milou");
+		});
 
-        it("super rebinds calls to that correctly", function() {
-            var animal = object.subclass(function(that, my) {
+		it("super can be called within protected methods", function() {
+			var animal = object.subclass(function(that, my) {
+				my.initialize = function(spec) {
+					my.super();
+					my.name = spec.name;
+				};
 
-                that.toString = function() {
-                    return my.getName();
-                };
+				that.toString = function() {
+					return my.getName();
+				};
 
-                my.getName = function() {
-                    return my.name;
-                };
-            });
+				my.getName = function() {
+					return my.name;
+				};
+			});
 
-            var dog = animal.subclass(function(that, my) {
-                that.toString = function() {
-                    return "a dog named: " + that.super();
-                };
+			var dog = animal.subclass(function(that, my) {
+				my.getName = function() {
+					return "dog named " + my.super();
+				};
+			});
 
-                my.getName = function() {
-                    return "milou";
-                };
-            });
+			var milou = dog.new({name: "milou"});
+
+			expect(milou.toString()).toEqual("dog named milou");
+		});
+
+		it("super rebinds calls to that correctly", function() {
+			var animal = object.subclass(function(that, my) {
+
+				that.toString = function() {
+					return my.getName();
+				};
+
+				my.getName = function() {
+					return my.name;
+				};
+			});
+
+			var dog = animal.subclass(function(that, my) {
+				that.toString = function() {
+					return "a dog named: " + that.super();
+				};
+
+				my.getName = function() {
+					return "milou";
+				};
+			});
 
 			var milou = dog.new();
 
-            expect(milou.toString()).toEqual("a dog named: milou");
-        });
+			expect(milou.toString()).toEqual("a dog named: milou");
+		});
 
-        it("super can be used with arguments", function() {
-            var animal = object.subclass(function(that, my) {
+		it("super can be used with arguments", function() {
+			var animal = object.subclass(function(that, my) {
 
-                that.foo = function(number) {
-                    return number;
-                };
-            });
+				that.foo = function(number) {
+					return number;
+				};
+			});
 
-            var dog = animal.subclass(function(that, my) {
-                that.foo = function(number) {
-                    return that.super(number) + 1;
-                };
-            });
+			var dog = animal.subclass(function(that, my) {
+				that.foo = function(number) {
+					return that.super(number) + 1;
+				};
+			});
 
 			var milou = dog.new();
-            var foo = milou.foo(4);
+			var foo = milou.foo(4);
 
-            expect(foo).toEqual(5);
-        });
+			expect(foo).toEqual(5);
+		});
 
 		it("super should be uninstalled after being used", function() {
 			var animal = object.subclass(function(that, my) {
@@ -134,5 +134,5 @@ define(["src/object"], function(object) {
 
 			expect(baz.new().foo()).toBe(2);
 		});
-    });
+	});
 });


### PR DESCRIPTION
Based on #18

It would be a lot easier with a spec object passed at creation as, as it is now,
the meta-class is created and instantiated before its behavior can be defined, 
leading to some spaghetti code to inject it afterward

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/foretagsplatsen/objectjs/19)

<!-- Reviewable:end -->
