### PR TITLE
Lower the number of nodejs versions we test on

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: node_js
 node_js:
-  - "5"
-  - "5.1"
+  - "6"
+  - "6.5"
   - "4"
-  - "4.2"
-  - "4.1"
-  - "4.0"
+  - "4.4"
   - "iojs"
 script:
   - gulp


### PR DESCRIPTION
The goal is twofold:

- make continuous integration faster

- avoid warnings when our codebase becomes incompatible with an
  unsupported version of nodejs.

The commit:

- removes nodejs 5 and 5.1 because those are unsupported
  releases (https://nodejs.org/en/blog/community/v5-to-v7/)

- replaces old releases (4.0, 4.1. 4.2) by newer ones (4.4)

- adds testing on version 6