### PR TITLE
Add pre/post initialization hooks

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -57,17 +57,33 @@ define([], function() {
 		};
 
 		/**
+		 * preInitialize is called by the framework at the beginning
+		 * of object instantiation.
+		 */
+		my.preInitialize = function() {};
+
+		/**
 		 * initialize is called by the framework upon object instantiation.
 		 */
 		my.initialize = function() {};
 
 		/**
-		 * Offer a hook for subclasses to allow them to control more
-		 * specifically the initialization process (especially the order).
+		 * postInitialize is called by the framework at the end of
+		 * object instantiation.
+		 */
+		my.postInitialize = function() {};
+
+		/**
+		 * Private method handling initialization of new
+		 * instances. Prefer overriding one of `preInitialize`,
+		 * `initialize` or `postInitialize` instead of overriding this
+		 * method.
 		 */
 		my.basicInitialize = function() {
 			var args = Array.prototype.slice.apply(arguments);
+			my.preInitialize.apply(this, args);
 			my.initialize.apply(this, args);
+			my.postInitialize.apply(this, args);
 		};
 
 		/**

--- a/src/object.js
+++ b/src/object.js
@@ -74,19 +74,6 @@ define([], function() {
 		my.postInitialize = function() {};
 
 		/**
-		 * Private method handling initialization of new
-		 * instances. Prefer overriding one of `preInitialize`,
-		 * `initialize` or `postInitialize` instead of overriding this
-		 * method.
-		 */
-		my.basicInitialize = function() {
-			var args = Array.prototype.slice.apply(arguments);
-			my.preInitialize.apply(this, args);
-			my.initialize.apply(this, args);
-			my.postInitialize.apply(this, args);
-		};
-
-		/**
 		 * Throws an error because the method should have been overridden.
 		 */
 		my.subclassResponsibility = subclassResponsibility;
@@ -190,7 +177,9 @@ define([], function() {
 			}
 
 			if (!notFinal) {
-				my.basicInitialize(spec);
+				my.preInitialize(spec);
+				my.initialize(spec);
+				my.postInitialize(spec);
 			}
 
 			return instance;

--- a/test/src/initializationSpec.js
+++ b/test/src/initializationSpec.js
@@ -77,5 +77,34 @@ define(["src/object"], function(object) {
             expect(d.foo).toEqual(1);
             expect(d.bar).toEqual(2);
         });
+
+        it("initialization hooks are called in order", function() {
+            // TODO: refactor that when
+            // https://github.com/jasmine/jasmine/pull/1242 is merged.
+            var spy = jasmine.createSpy("spy");
+
+            var animal = object.subclass(function(that, my) {
+                my.preInitialize = function() {
+                    my.super();
+                    expect(spy.calls.count()).toBe(0);
+                    spy();
+                };
+
+                my.initialize = function() {
+                    my.super();
+                    expect(spy.calls.count()).toBe(1);
+                    spy();
+                };
+
+                my.postInitialize = function() {
+                    my.super();
+                    expect(spy.calls.count()).toBe(2);
+                    spy();
+                };
+            });
+
+            animal();
+            expect(spy.calls.count()).toEqual(3);
+        });
     });
 });


### PR DESCRIPTION
Please avoid overriding `basicInitialize()` as it's now considered a
private method.