### PR TITLE
F7263902263: Remove the "main" entry in klassified's package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
 	"name": "klassified",
 	"version": "4.0.0",
 	"description": "A simple object model for JavaScript",
-	"main": "dist/klassified.min.js",
-	"module": "src/klassified.js",
+	"main": "src/klassified.js",
 	"type": "module",
 	"directories": {
 		"test": "test"


### PR DESCRIPTION
The file it references doesn't exist.

basecamp: https://3.basecamp.com/4201305/buckets/32129139/todos/7263926533

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/foretagsplatsen/klassified/133)
<!-- Reviewable:end -->
